### PR TITLE
(fix) Fix resume persistence when new user uploads resume for first time

### DIFF
--- a/client/src/components/Dashboard.jsx
+++ b/client/src/components/Dashboard.jsx
@@ -27,11 +27,7 @@ class Dashboard extends React.Component {
       nameOnly: 'Guest',
       resume_id: null
     };
-  }
-
-  componentWillMount() {
     this.nameChange();
-    // console.log('!!!!!!!!!!!!!!', this.props)
   }
 
   nameChange() {
@@ -43,12 +39,10 @@ class Dashboard extends React.Component {
     })
     .done(function(data) {
       if (data.email) {
-        console.log('success GET', data);
         context.setState({
           name: 'Welcome Back, '+data.display +'!',
           avatar: data.avatar,
-          nameOnly: data.display,
-          resume_id: data.resume_id
+          nameOnly: data.display
         });
       }
     })
@@ -78,7 +72,7 @@ class Dashboard extends React.Component {
           <Route path="/jobs" component={JobList} />
           <Route path="/companyInfo" component={CompanyInfo} />
           <Route path="/analytics" component={Analytics} />
-          <Route path="/resume" component={(props) => <Resume resume_id={this.state.resume_id}/>} />
+          <Route path="/resume" component={Resume} />
           <Route path="/settings" component={Settings} />
           <Route path='/home' component={Home} />
 

--- a/client/src/components/Resume.jsx
+++ b/client/src/components/Resume.jsx
@@ -40,32 +40,44 @@ class Resume extends React.Component {
       total: null
     };
     
-    console.log('PROPS', props);
-
     this.progress = this.progress.bind(this);
     this.onDocumentCompleted = this.onDocumentCompleted.bind(this);
     this.onPageCompleted = this.onPageCompleted.bind(this);
-    
-    let context = this;
-
-    $.ajax({
-      url: '/getResume',
-      type: 'GET',
-      data: {resume_id: props.resume_id},
-      success: function(resume) {
-        console.log('Got resume info', resume);
-        context.setState({
-          skills: resume.skills.split(','),
-          file: resume.resume_url
-        });
-      }
-    });
+    this.getResume();
   }
 
 
   // Set progress bar to zero on page load
   componentWillUnmount() {
     this.setState({completed: 0});
+  }
+
+  getResume() {
+    let context = this;
+    $.ajax({
+      type: 'GET',
+      url: '/user',
+      datatype: 'json'
+    })
+    .done((user) => {
+      $.ajax({
+        url: '/getResume',
+        type: 'GET',
+        data: {resume_id: user.resume_id},
+      })
+      .done((resume) => {
+        context.setState({
+          skills: resume.skills.split(','),
+          file: resume.resume_url
+        });
+      })
+      .fail(function(err) {
+        console.log('failed to GET', err);
+      });
+    })
+    .fail(function(err) {
+      console.log('failed to GET', err);
+    });
   }
 
   getSignedRequest(file) {
@@ -107,7 +119,7 @@ class Resume extends React.Component {
   // Needed to render skills chips (Material-UI component)
   renderChip(data) {
     return (
-      <Chip style={styles.chip}>
+      <Chip style={styles.chip} key={Math.random() * 1000}>
         {data}
       </Chip>
     );
@@ -126,7 +138,7 @@ class Resume extends React.Component {
             url: '/fileUpload',
             type: 'POST',
             data: context.state.file,
-            success: function(data) {
+            success: function(data) { 
               console.log('Upload succeeded');
               context.setState({skills: data});
             },


### PR DESCRIPTION
Fixes a resume database fetching issue: when a user uploads their resume for the first time and clicks out of the resume component (i.e. clicks on home, or settings) and then clicks back to resume, their freshly uploaded resume isn't loading to screen.

Added a function that calls /user, then chains /getResume